### PR TITLE
Mise à jour des noms des canaux GPS et Démat

### DIFF
--- a/matterbridge.toml
+++ b/matterbridge.toml
@@ -134,7 +134,7 @@
 
 [[gateway.inout]]
     account="slack.itou"
-    channel="c7-gps"
+    channel="gps"
 
 
 [[gateway]]
@@ -173,4 +173,4 @@
 
 [[gateway.inout]]
     account="slack.itou"
-    channel="c2-dematconventionnement"
+    channel="demat-conventionnement"


### PR DESCRIPTION
Les noms des canaux #gps et #demat-conventionnement ont été mis à jour de manière prématurée.